### PR TITLE
Add student portfolio & resume section placeholder to web UI and backend API

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,23 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+student_portfolios = {
+    # Example entry
+    # "michael@mergington.edu": {
+    #     "name": "Michael Smith",
+    #     "grade": "11",
+    #     "achievements": ["Chess Club Winner 2024", "Math Olympiad Finalist"],
+    #     "leadership_roles": ["Chess Club President"]
+    # }
+}
+
+@app.get("/portfolio/{email}")
+def get_student_portfolio(email: str):
+    """Get a student's portfolio by email"""
+    portfolio = student_portfolios.get(email)
+    if not portfolio:
+        raise HTTPException(status_code=404, detail="Portfolio not found")
+    return portfolio]
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")

--- a/src/app.py
+++ b/src/app.py
@@ -26,7 +26,7 @@ def get_student_portfolio(email: str):
     portfolio = student_portfolios.get(email)
     if not portfolio:
         raise HTTPException(status_code=404, detail="Portfolio not found")
-    return portfolio]
+    return portfolio
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -39,6 +39,12 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+      <section id="portfolio-container">
+        <h3>Student Portfolio & Resume</h3>
+        <div id="portfolio-content">
+          <p>Coming soon: Students will be able to showcase their achievements, education, and leadership roles here.</p>
+        </div>
+      </section>
     </main>
 
     <footer>


### PR DESCRIPTION
This PR adds a new section to the web interface for student portfolios and resumes, allowing students to showcase achievements, education, and leadership roles. It also introduces a backend API endpoint for retrieving student portfolio data (currently placeholder).